### PR TITLE
Closes #123

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,59 @@
+# configure updates globally
+# default: all
+# allowed: all, insecure, False
+update: all
+
+# configure dependency pinning globally
+# default: True
+# allowed: True, False
+pin: True
+
+# set the default branch
+# default: empty, the default branch on GitHub
+branch: develop
+
+# update schedule
+# default: empty
+# allowed: "every day", "every week", ..
+schedule: "every week on sunday"
+
+# search for requirement files
+# default: True
+# allowed: True, False
+search: True
+
+# Specify requirement files by hand, default is empty
+# default: empty
+# allowed: list
+requirements:
+  - requirements/staging.txt:
+      # update all dependencies and pin them
+      update: all
+      pin: True
+  - requirements/develop.txt:
+      # don't update dependencies, use global 'pin' default
+      update: False
+  - requirements/production.txt:
+      # update insecure only, pin all
+      update: insecure
+      pin: True
+
+# add a label to pull requests, default is not set
+# requires private repo permissions, even on public repos
+# default: empty
+label_prs: update
+
+# assign users to pull requests, default is not set
+# requires private repo permissions, even on public repos
+# default: empty
+assignees:
+  - tomvothecoder
+
+# configure the branch prefix the bot is using
+# default: pyup-
+branch_prefix: pyup/
+
+
+# allow to close stale PRs
+# default: True
+close_prs: True


### PR DESCRIPTION
Add pyup configuration to minimize the noise caused by constant pull requests. Pyup should now only have a single pull request containing all of the updated dependencies every week on Sundays.